### PR TITLE
Add "AUDIT_WRITE" to TestNode podman capabilities

### DIFF
--- a/ceph_devstack/resources/ceph/containers.py
+++ b/ceph_devstack/resources/ceph/containers.py
@@ -155,6 +155,7 @@ class TestNode(Container):
         "CHOWN",
         "SYS_PTRACE",
         "SYS_TTY_CONFIG",
+        "AUDIT_WRITE",
     ]
     create_cmd = [
         "podman",


### PR DESCRIPTION
When trying to ssh from teuthology container to a testnode container, it fails and testnode container's sshd journal logs show: "fatal: linux_audit_write_entry failed: Operation not permitted" .
This PR fixes that issue.