### PR TITLE
Add "AUDIT_CONTROL" to TestNode capabilities

### DIFF
--- a/ceph_devstack/resources/ceph/containers.py
+++ b/ceph_devstack/resources/ceph/containers.py
@@ -160,6 +160,7 @@ class TestNode(Container):
         "SYS_PTRACE",
         "SYS_TTY_CONFIG",
         "AUDIT_WRITE",
+        "AUDIT_CONTROL",
     ]
     create_cmd = [
         "podman",


### PR DESCRIPTION
"AUDIT_WRITE" fixed the issue of ssh-ing from teuthoology to testnode for only root user :(
When trying to ssh to "ubuntu" user of testnode, it fails. I get the following error in journal logs of the testnode:

```
Feb 23 08:44:25 8e6e0f8cb66c sshd[147]: Accepted publickey for ubuntu from <IP> port <PORT> ssh2: RSA SHA256: <public key fingerprint>
Feb 23 08:44:25 8e6e0f8cb66c sshd[147]: pam_loginuid(sshd:session): Error writing /proc/self/loginuid: Operation not permitted
Feb 23 08:44:25 8e6e0f8cb66c sshd[147]: pam_loginuid(sshd:session): set_loginuid failed
Feb 23 08:44:25 8e6e0f8cb66c sshd[147]: pam_systemd(sshd:session): Failed to create session: Unit systemd-logind.service is masked.
Feb 23 08:44:25 8e6e0f8cb66c sshd[147]: pam_unix(sshd:session): session opened for user ubuntu by (uid=0)
Feb 23 08:44:25 8e6e0f8cb66c sshd[147]: error: PAM: pam_open_session(): Cannot make/remove an entry for the specified session
```

Podman's documentation to troubleshoot above problem:
https://github.com/containers/podman/blob/main/troubleshooting.md#33-the-sshd-process-fails-to-run-inside-of-the-container


I got a successful run for `teuthology:no-ceph` suite with "quay.io/ceph-infra/teuthology-dev:devstack-simplified" after this change. 