### PR TITLE
Allow authentication with real ssh key and also forwarded agent key

### DIFF
--- a/ceph_devstack/resources/ceph/__init__.py
+++ b/ceph_devstack/resources/ceph/__init__.py
@@ -74,7 +74,7 @@ class SSHKeyPair(Secret):
                 check=True,
                 force_local=True,
             )
-            self.pubkey_path = f"{privkey_path}.pub"
+        self.pubkey_path = f"{privkey_path}.pub"
         self.privkey_path = privkey_path
 
 

--- a/ceph_devstack/resources/ceph/containers.py
+++ b/ceph_devstack/resources/ceph/containers.py
@@ -333,6 +333,14 @@ class Teuthology(Container):
                 "-v",
                 f"{ansible_inv}/secrets:/etc/ansible/secrets",
             ]
+        ssh_auth_socket = os.environ.get("SSH_AUTH_SOCK")
+        if ssh_auth_socket:
+            cmd += [
+                "-v",
+                f"{ssh_auth_socket}:{ssh_auth_socket}",
+                "-e",
+                f"SSH_AUTH_SOCK={ssh_auth_socket}",
+            ]
         cmd += [
             "--name",
             "{name}",


### PR DESCRIPTION
Couple fixes to use ceph-devstack with real testnodes.