### PR TITLE
config.toml: change teuthology image tag to "main"

### DIFF
--- a/ceph_devstack/config.toml
+++ b/ceph_devstack/config.toml
@@ -20,4 +20,4 @@ count = 3
 image = "quay.io/ceph-infra/teuthology-testnode:latest"
 
 [containers.teuthology]
-image = "quay.io/ceph-infra/teuthology-dev:latest"
+image = "quay.io/ceph-infra/teuthology-dev:main"


### PR DESCRIPTION
Because new teuthology-dev images are pushed to
"main" tag by teuthology dev_container GA workflow: https://github.com/ceph/teuthology/blob/e14d4550c474ba80474d8dbfb1221d9e4633ad5f/.github/workflows/dev_container.yml#L29