### PR TITLE
testnode: add config entry for osd count per testnode

### DIFF
--- a/ceph_devstack/resources/ceph/containers.py
+++ b/ceph_devstack/resources/ceph/containers.py
@@ -180,8 +180,10 @@ class TestNode(Container):
         self.index = 0
         if "_" in self.name:
             self.index = int(self.name.split("_")[-1])
-        self.osd_count = config["containers"]["testnode"].get("osd_count", 1)
-        self.devices = [self.device_name(i) for i in range(self.osd_count)]
+        self.loop_device_count = config["containers"]["testnode"].get(
+            "loop_device_count", 1
+        )
+        self.devices = [self.device_name(i) for i in range(self.loop_device_count)]
 
     @property
     def loop_img_dir(self):
@@ -321,7 +323,7 @@ class TestNode(Container):
             os.remove(loop_img_name)
 
     def device_name(self, index: int):
-        return f"/dev/loop{self.osd_count * self.index + index}"
+        return f"/dev/loop{self.loop_device_count * self.index + index}"
 
     def device_image(self, device: str):
         return f"{self.name}-{device.lstrip('/dev/loop')}"

--- a/ceph_devstack/resources/ceph/containers.py
+++ b/ceph_devstack/resources/ceph/containers.py
@@ -280,7 +280,7 @@ class TestNode(Container):
             await self.cmd(["sudo", "modprobe", "loop"])
         loop_img_name = os.path.join(self.loop_img_dir, self.device_image(device))
         await self.remove_loop_device(device)
-        device_pos = device.lstrip("/dev/loop")
+        device_pos = device.removeprefix("/dev/loop")
         await self.cmd(
             [
                 "sudo",
@@ -326,7 +326,7 @@ class TestNode(Container):
         return f"/dev/loop{self.loop_device_count * self.index + index}"
 
     def device_image(self, device: str):
-        return f"{self.name}-{device.lstrip('/dev/loop')}"
+        return f"{self.name}-{device.removeprefix('/dev/loop')}"
 
 
 class Teuthology(Container):

--- a/ceph_devstack/resources/test/fixtures/testnode-config.toml
+++ b/ceph_devstack/resources/test/fixtures/testnode-config.toml
@@ -1,0 +1,2 @@
+[containers.testnode]
+loop_device_count = 4

--- a/ceph_devstack/resources/test/test_testnode.py
+++ b/ceph_devstack/resources/test/test_testnode.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+import pytest
+
+from ceph_devstack.resources.ceph import TestNode
+from ceph_devstack import config
+
+
+class TestTestnode:
+    @pytest.fixture(scope="class")
+    def cls(self) -> type[TestNode]:
+        return TestNode
+
+    def test_testnode_loop_device_count_default_to_one(self, cls):
+        testnode = cls("testnode_1")
+        assert testnode.loop_device_count == 1
+
+    def test_testnode_create_cmd_includes_related_devices(self, cls):
+        config.load(Path(__file__).parent.joinpath("fixtures", "testnode-config.toml"))
+        testnode = cls("testnode_1")
+        create_cmd = testnode.create_cmd
+        assert "--device=/dev/loop4" in create_cmd
+        assert "--device=/dev/loop5" in create_cmd
+        assert "--device=/dev/loop6" in create_cmd
+        assert "--device=/dev/loop7" in create_cmd
+
+    def test_testnode_devices_is_based_on_loop_device_count_config(self, cls):
+        testnode = cls("testnode_1")
+        assert testnode.loop_device_count == 4
+        assert testnode.devices == [
+            "/dev/loop4",
+            "/dev/loop5",
+            "/dev/loop6",
+            "/dev/loop7",
+        ]


### PR DESCRIPTION
The goal of this PR is to support multiple OSDs per testnode in ceph-devstack. It includes:
- new `containers.testnode.storage_device_count` config option
- changes in `Testnode.create` to create loop devices according to the config option
- supports to include additional options in sshd_config (needed to runs suite like `orch:cephadm:smoke`
