### PR TITLE
testnode: allow storage device size config

### DIFF
--- a/ceph_devstack/config.toml
+++ b/ceph_devstack/config.toml
@@ -17,6 +17,7 @@ image = "quay.io/ceph-infra/pulpito:main"
 
 [containers.testnode]
 count = 3
+loop_device_size = "5G"
 image = "quay.io/ceph-infra/teuthology-testnode:main"
 
 [containers.teuthology]

--- a/ceph_devstack/resources/ceph/containers.py
+++ b/ceph_devstack/resources/ceph/containers.py
@@ -246,7 +246,7 @@ class TestNode(Container):
         await self.remove_loop_device()
 
     async def create_loop_device(self):
-        size_gb = 5
+        size = config["containers"]["testnode"]["loop_device_size"]
         os.makedirs(self.loop_img_dir, exist_ok=True)
         proc = await self.cmd(["lsmod", "|", "grep", "loop"])
         if proc and await proc.wait() != 0:
@@ -277,7 +277,7 @@ class TestNode(Container):
                 f"of={loop_img_name}",
                 "bs=1",
                 "count=0",
-                f"seek={size_gb}G",
+                f"seek={size}",
             ],
             check=True,
         )


### PR DESCRIPTION
The goal of this PR is to allow the configuration of created loop devices. It's achieved with a new config entry `containers.testnode.loop_device_size` 