### PR TITLE
.github/workflows: Add release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: "Publish release to PyPI"
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - name: Install Python 3.13
+        run: uv python install 3.13
+      - name: Build
+        run: rm -rf dist && uv build
+      - name: Smoke test (wheel)
+        run: uv run --isolated --no-project --with (ls dist/*.whl)\[test\] pytest tests
+      - name: Smoke test (source distribution)
+        run: uv run --isolated --no-project --with (ls dist/*.tar.gz)\[test\] pytest tests
+      - name: Publish
+        run: uv publish


### PR DESCRIPTION
This will only run on tag operations. I can't test this before merging, so I will follow up as necessary.